### PR TITLE
add remote update notify

### DIFF
--- a/BTAS.js
+++ b/BTAS.js
@@ -14,8 +14,12 @@
 // @grant        GM_registerMenuCommand
 // @grant        GM_unregisterMenuCommand
 // ==/UserScript==
+
 var $ = window.jQuery;
+
 const LogSourceDomain = $('#customfield_10223-val').text().trim();
+const Labels = $('.labels-wrap .labels li a span').text();
+const LogSource = $('#customfield_10204-val').text().trim();
 const rawLog = $('#field-customfield_10219 > div:first-child > div:nth-child(2)').text().trim().split('\n');
 
 /**
@@ -217,11 +221,11 @@ function editNotify() {
             http://172.18.2.13/books/customers/page/lsh-hk-lei-shing-hong-hk',
         'toysrus':
             'If the alert is related to Malicious or Unwanted software, there is NO NEED to escalate.<br>\
-            Please help the customer run full scan on MDE and then close ticket. Finally, add full scan screenshots in internal comments'
+            Please help the customer run full scan on MDE and then close ticket. Finally, add full scan screenshots in internal comments',
+        'Auto Escalate':
+            'All automatically upgraded tickets can NOT be closed directly, and need to be upgraded to the customer. Only need to add a description and ATT&CK, and wait for the customer to confirm before closing'
     };
-    const LogSourceDomain = $('#customfield_10223-val').text().trim();
-    const Labels = $('.labels-wrap .labels li a span').text();
-    const LogSource = $('#customfield_10204-val').text().trim();
+
     function addEditonClick() {
         // # Add a click event listener to the "Edit" button related to the "LogSourceDomain" field
         if (
@@ -268,6 +272,13 @@ function editNotify() {
             const orgNotify = orgNotifydict['Dev Team'];
             $('#edit-issue').on('click', () => {
                 showFlag('warning', `${LogSource} ticket`, `${orgNotify}`, 'manual');
+            });
+        }
+        // # Add a click event listener to the "Resolve this issue" button related to the "Log Source Domain" field
+        if ($('#customfield_12202-val').text().trim() == 'Yes') {
+            const orgNotify = orgNotifydict['Auto Escalate'];
+            $('#action_id_761').on('click', () => {
+                showFlag('warning', `Auto Escalate ticket`, `${orgNotify}`, 'manual');
             });
         }
     }

--- a/BTAS.js
+++ b/BTAS.js
@@ -49,7 +49,7 @@ function registerSearchMenu() {
                 '%22Log%20Source%20Domain%22%20~%20%22%D%22%20' +
                 'ORDER%20BY%20created%20DESC'
         },
-        { name: 'Reputation', url: 'https://172.18.2.23/instance/execute/reputation/ip?ip=%s' },
+        // { name: 'Reputation', url: 'https://172.18.2.23/instance/execute/reputation/ip?ip=%s' },
         { name: 'VT', url: 'https://www.virustotal.com/gui/search/%s' },
         { name: 'AbuseIPDB', url: 'https://www.abuseipdb.com/check/%s' }
     ];

--- a/BTAS.js
+++ b/BTAS.js
@@ -112,11 +112,13 @@ function createNotifyControls() {
         parentNode.prepend(audioControl);
     }
 
-    function createCheckbox(parentNode, localStorageKey) {
+    function createCheckbox(parentNode, localStorageKey, checkStatus) {
         const checkbox = $('<span></span>');
         const value = localStorage.getItem(localStorageKey);
         checkbox.html(
-            `<input type="checkbox" name="${localStorageKey}" ${value == 'true' ? 'checked' : ''}>${localStorageKey}`
+            `<input type="checkbox" name="${localStorageKey}" ${
+                value == 'true' ? 'checked' : checkStatus ? 'checked' : ''
+            }>${localStorageKey}`
         );
         checkbox.find('input').on('click', () => {
             localStorage.setItem(localStorageKey, checkbox.find('input').prop('checked'));
@@ -125,9 +127,9 @@ function createNotifyControls() {
         return checkbox;
     }
     createAudioControl(operationsBar);
-    const audioCheckbox = createCheckbox(operationsBar, 'audioNotify');
-    const keepCheckbox = createCheckbox(operationsBar, 'keepAudio');
-    const promptCheckbox = createCheckbox(operationsBar, 'prompt');
+    const audioCheckbox = createCheckbox(operationsBar, 'audioNotify', false);
+    const keepCheckbox = createCheckbox(operationsBar, 'keepAudio', false);
+    const promptCheckbox = createCheckbox(operationsBar, 'prompt', true);
 
     return { audioControl, audioCheckbox, keepCheckbox, promptCheckbox };
 }
@@ -486,7 +488,9 @@ function MDEAlertHandler() {
     function parseLog(rawLog) {
         const alertInfo = rawLog.reduce((acc, log) => {
             try {
-                const { mde } = JSON.parse(log);
+                const formatJson = log.substring(log.indexOf('{')).trim();
+                const logObj = JSON.parse(formatJson.replace(/\\\(n/g, '\\n('));
+                const { mde } = logObj;
                 const { title, id, computerDnsName, relatedUser, evidence } = mde;
                 const alert = { title, id, computerDnsName };
                 const userName = relatedUser ? relatedUser.userName : 'N/A';

--- a/BTAS.js
+++ b/BTAS.js
@@ -2,7 +2,7 @@
 // @name         BTAS
 // @namespace    https://github.com/Ripper-S/BTAS
 // @homepageURL  https://github.com/Ripper-S/BTAS
-// @version      1.4.6
+// @version      1.4.7
 // @description  Blue Team Assistance Script
 // @author       Barry Y Yang; Jack SA Chen; Xingyu X Zhou
 // @license      Apache-2.0

--- a/BTAS.js
+++ b/BTAS.js
@@ -2,7 +2,7 @@
 // @name         BTAS
 // @namespace    https://github.com/Ripper-S/BTAS
 // @homepageURL  https://github.com/Ripper-S/BTAS
-// @version      1.4.5
+// @version      1.4.6
 // @description  Blue Team Assistance Script
 // @author       Barry Y Yang; Jack SA Chen; Xingyu X Zhou
 // @license      Apache-2.0
@@ -829,10 +829,8 @@ function WineventAlertHandler() {
 
     // Issue page: Alert Handler
     setInterval(() => {
-        if ($('#issue-content').length && !$('#generateDescription').length && !$('.aui-banner-error').length) {
+        if ($('#issue-content').length && !$('#generateDescription').length) {
             console.log('#### Code Issue page: Alert Handler ####');
-            checkKeywords();
-
             const handlers = {
                 'cortex-xdr-json': cortexAlertHandler,
                 'mde-api-json': MDEAlertHandler,
@@ -846,6 +844,14 @@ function WineventAlertHandler() {
             if (handler) {
                 handler();
             }
+        }
+    }, 3000);
+
+    // Issue page: check Keywords
+    setInterval(() => {
+        if ($('#issue-content').length && !$('.aui-banner-error').length) {
+            console.log('#### Code Issue page: check Keywords ####');
+            checkKeywords();
         }
     }, 3000);
 

--- a/BTAS.js
+++ b/BTAS.js
@@ -214,7 +214,9 @@ function editNotify() {
         http://172.18.2.13/books/customers/page/lsh-hk-lei-shing-hong-hk',
         'Dev Team':
             'Please do NOT escalate to the customer<br>\
-        AND contact Dev Team via Teams Conversation first to confirm if it is due to their operatation'
+        AND contact Dev Team via Teams Conversation first to confirm if it is due to their operatation',
+        'toysrus':
+            'If the alert is related to Malicious or Unwanted software, there is NO NEED to escalate.<br> Please help the customer run full scan on MDE and then close ticket. Finally, add full scan screenshots in internal comments'
     };
     const LogSourceDomain = $('#customfield_10223-val').text().trim();
     const Labels = $('.labels-wrap .labels li a span').text();
@@ -224,7 +226,8 @@ function editNotify() {
         if (
             LogSourceDomain.includes('esf') ||
             LogSourceDomain.includes('swireproperties') ||
-            LogSourceDomain.includes('lsh-hk')
+            LogSourceDomain.includes('lsh-hk') ||
+            LogSourceDomain.includes('toysrus')
         ) {
             const orgNotify = orgNotifydict[LogSourceDomain];
             $('#edit-issue').on('click', () => {

--- a/BTAS.js
+++ b/BTAS.js
@@ -2,7 +2,7 @@
 // @name         BTAS
 // @namespace    https://github.com/Ripper-S/BTAS
 // @homepageURL  https://github.com/Ripper-S/BTAS
-// @version      1.4.3
+// @version      1.4.4
 // @description  Blue Team Assistance Script
 // @author       Barry Y Yang; Jack SA Chen; Xingyu X Zhou
 // @license      Apache-2.0
@@ -210,37 +210,26 @@ function editNotify() {
         http://172.18.2.13/books/customers/page/lsh-hk-lei-shing-hong-hk',
         'plwazag':
             'When processing a ticket containing "plwazag" in the Log Source<br>\
+        Please do NOT escalate to the customer and contact Dev Team via Teams Conversation first to confirm if it is due to their operatation',
+        'LogCollector':
+            'When processing a ticket containing "LogCollector" in the Log Source<br>\
         Please do NOT escalate to the customer and contact Dev Team via Teams Conversation first to confirm if it is due to their operatation'
     };
     const LogSourceDomain = $('#customfield_10223-val').text().trim();
-    const orgNotify = orgNotifydict[LogSourceDomain];
     const Labels = $('.labels-wrap .labels li a span').text();
     const LogSource = $('#customfield_10204-val').text().trim();
     function addEditonClick() {
-        // # Add a click event listener to the "Edit" button
+        // # Add a click event listener to the "Edit" button related to the "LogSourceDomain" field
         if (
             LogSourceDomain.includes('esf') ||
             LogSourceDomain.includes('swireproperties') ||
-            LogSourceDomain.includes('lsh-hk') ||
-            LogSource.includes('plwazag')
+            LogSourceDomain.includes('lsh-hk')
         ) {
+            const orgNotify = orgNotifydict[LogSourceDomain];
             $('#edit-issue').on('click', () => {
                 showFlag('warning', `${LogSourceDomain} ticket`, `${orgNotify}`, 'manual');
             });
         }
-        // # Add a click event listener to the "Edit" button for LogCollector tickets
-        if (LogSource.includes('LogCollector')) {
-            $('#edit-issue').on('click', () => {
-                showFlag(
-                    'warning',
-                    'LogCollector ticket',
-                    'When processing a ticket containing "LogCollector" in the Log Source<br>\
-                Please do NOT escalate to the customer and contact Jones/Franky first to confirm if it is due to other reasons',
-                    'manual'
-                );
-            });
-        }
-        // # Add a click event listener to the "Edit" button for kerrypropshk tickets
         if (LogSourceDomain.includes('kerrypropshk')) {
             if (Labels === 'UnassignedGroup') {
                 $('#edit-issue').on('click', () => {
@@ -264,6 +253,14 @@ function editNotify() {
                     );
                 });
             }
+        }
+        // # Add a click event listener to the "Edit" button related to the "LogSource" field
+        if (LogSource.includes('plwazag') || LogSource.includes('LogCollector')) {
+            const keyLS = LogSource.includes('plwazag') ? 'plwazag' : LogSource;
+            const orgNotify = orgNotifydict[keyLS];
+            $('#edit-issue').on('click', () => {
+                showFlag('warning', `${keyLS} ticket`, `${orgNotify}`, 'manual');
+            });
         }
     }
     addEditonClick();

--- a/BTAS.js
+++ b/BTAS.js
@@ -2,7 +2,7 @@
 // @name         BTAS
 // @namespace    https://github.com/Ripper-S/BTAS
 // @homepageURL  https://github.com/Ripper-S/BTAS
-// @version      1.4.2
+// @version      1.4.3
 // @description  Blue Team Assistance Script
 // @author       Barry Y Yang; Jack SA Chen; Xingyu X Zhou
 // @license      Apache-2.0
@@ -222,7 +222,7 @@ function editNotify() {
             LogSourceDomain.includes('esf') ||
             LogSourceDomain.includes('swireproperties') ||
             LogSourceDomain.includes('lsh-hk') ||
-            LogSourceDomain.includes('plwazag')
+            LogSource.includes('plwazag')
         ) {
             $('#edit-issue').on('click', () => {
                 showFlag('warning', `${LogSourceDomain} ticket`, `${orgNotify}`, 'manual');

--- a/BTAS.js
+++ b/BTAS.js
@@ -2,7 +2,7 @@
 // @name         BTAS
 // @namespace    https://github.com/Ripper-S/BTAS
 // @homepageURL  https://github.com/Ripper-S/BTAS
-// @version      1.4.4
+// @version      1.4.5
 // @description  Blue Team Assistance Script
 // @author       Barry Y Yang; Jack SA Chen; Xingyu X Zhou
 // @license      Apache-2.0
@@ -208,12 +208,9 @@ function editNotify() {
         'lsh-hk':
             'Please escalated according to the Label tags and document.<br>\
         http://172.18.2.13/books/customers/page/lsh-hk-lei-shing-hong-hk',
-        'plwazag':
-            'When processing a ticket containing "plwazag" in the Log Source<br>\
-        Please do NOT escalate to the customer and contact Dev Team via Teams Conversation first to confirm if it is due to their operatation',
-        'LogCollector':
-            'When processing a ticket containing "LogCollector" in the Log Source<br>\
-        Please do NOT escalate to the customer and contact Dev Team via Teams Conversation first to confirm if it is due to their operatation'
+        'Dev Team':
+            'Please do NOT escalate to the customer<br>\
+        AND contact Dev Team via Teams Conversation first to confirm if it is due to their operatation'
     };
     const LogSourceDomain = $('#customfield_10223-val').text().trim();
     const Labels = $('.labels-wrap .labels li a span').text();
@@ -255,15 +252,17 @@ function editNotify() {
             }
         }
         // # Add a click event listener to the "Edit" button related to the "LogSource" field
-        if (LogSource.includes('plwazag') || LogSource.includes('LogCollector')) {
-            const keyLS = LogSource.includes('plwazag') ? 'plwazag' : LogSource;
-            const orgNotify = orgNotifydict[keyLS];
+        if (
+            LogSource.includes('plwazag') ||
+            LogSource.includes('LogCollector') ||
+            LogSource.includes('.int.darklab.hk')
+        ) {
+            const orgNotify = orgNotifydict['Dev Team'];
             $('#edit-issue').on('click', () => {
-                showFlag('warning', `${keyLS} ticket`, `${orgNotify}`, 'manual');
+                showFlag('warning', `${LogSource} ticket`, `${orgNotify}`, 'manual');
             });
         }
     }
-
     addEditonClick();
 
     function generateEditnotify() {

--- a/BTAS.js
+++ b/BTAS.js
@@ -2,7 +2,7 @@
 // @name         BTAS
 // @namespace    https://github.com/Ripper-S/BTAS
 // @homepageURL  https://github.com/Ripper-S/BTAS
-// @version      1.4.8
+// @version      1.4.9
 // @description  Blue Team Assistance Script
 // @author       Barry Y Yang; Jack SA Chen; Xingyu X Zhou
 // @license      Apache-2.0

--- a/BTAS.js
+++ b/BTAS.js
@@ -15,6 +15,8 @@
 // @grant        GM_unregisterMenuCommand
 // ==/UserScript==
 var $ = window.jQuery;
+const LogSourceDomain = $('#customfield_10223-val').text().trim();
+const rawLog = $('#field-customfield_10219 > div:first-child > div:nth-child(2)').text().trim().split('\n');
 
 /**
  * This function creates and displays a flag using AJS.flag function
@@ -480,14 +482,6 @@ function cortexAlertHandler() {
 
 function MDEAlertHandler() {
     console.log('#### Code MDEAlertHandler run ####');
-    function extractLog() {
-        const LogSourceDomain = $('#customfield_10223-val').text().trim();
-        let rawLog = $('#field-customfield_10219 > div:first-child > div:nth-child(2)').text().trim().split('\n');
-        return { LogSourceDomain, rawLog };
-    }
-    const { LogSourceDomain, rawLog } = extractLog();
-    // console.info(`LogSourceDomain: ${LogSourceDomain}`);
-    // console.info(`rawLog: ${rawLog}`);
 
     function parseLog(rawLog) {
         const alertInfo = rawLog.reduce((acc, log) => {
@@ -549,20 +543,12 @@ function MDEAlertHandler() {
 
 function HTSCAlertHandler() {
     console.log('#### Code HTSCAlertHandler run ####');
+
     function decodeHtml(encodedString) {
         const tmpElement = document.createElement('span');
         tmpElement.innerHTML = encodedString;
         return tmpElement.innerText;
     }
-
-    function extractLog() {
-        const LogSourceDomain = $('#customfield_10223-val').text().trim();
-        let rawLog = $('#field-customfield_10219 > div:first-child > div:nth-child(2)').text().trim().split('\n');
-        return { LogSourceDomain, rawLog };
-    }
-    const { LogSourceDomain, rawLog } = extractLog();
-    // console.info(`LogSourceDomain: ${LogSourceDomain}`);
-    // console.info(`rawLog: ${rawLog}`);
 
     const parseLog = (rawLog) => {
         const alertInfo = rawLog.reduce((acc, log) => {
@@ -605,12 +591,6 @@ function HTSCAlertHandler() {
 
 function CBAlertHandler() {
     console.log('#### Code CBAlertHandler run ####');
-
-    function extractLog() {
-        const LogSourceDomain = $('#customfield_10223-val').text().trim();
-        let rawLog = $('#field-customfield_10219 > div:first-child > div:nth-child(2)').text().trim().split('\n');
-        return { LogSourceDomain, rawLog };
-    }
 
     // For Swire
     function parseLeefLog(rawLog) {
@@ -704,7 +684,6 @@ function CBAlertHandler() {
         return alertInfo;
     }
 
-    const { LogSourceDomain, rawLog } = extractLog();
     let alertInfo;
     if (LogSourceDomain == 'swireproperties') {
         alertInfo = parseLeefLog(rawLog);
@@ -746,12 +725,6 @@ function CBAlertHandler() {
 
 function WineventAlertHandler() {
     console.log('#### Code WineventAlertHandler run ####');
-    function extractLog() {
-        const LogSourceDomain = $('#customfield_10223-val').text().trim();
-        let rawLog = $('#field-customfield_10219 > div:first-child > div:nth-child(2)').text().trim().split('\n');
-        return { LogSourceDomain, rawLog };
-    }
-    const { LogSourceDomain, rawLog } = extractLog();
 
     function parseLog(rawLog) {
         const alertInfo = rawLog.reduce((acc, log) => {
@@ -840,6 +813,7 @@ function WineventAlertHandler() {
                 'windows_eventchannel': WineventAlertHandler
             };
             const DecoderName = $('#customfield_10807-val').text().trim();
+
             const handler = handlers[DecoderName];
             if (handler) {
                 handler();

--- a/BTAS.js
+++ b/BTAS.js
@@ -2,7 +2,7 @@
 // @name         BTAS
 // @namespace    https://github.com/Ripper-S/BTAS
 // @homepageURL  https://github.com/Ripper-S/BTAS
-// @version      1.4.7
+// @version      1.4.8
 // @description  Blue Team Assistance Script
 // @author       Barry Y Yang; Jack SA Chen; Xingyu X Zhou
 // @license      Apache-2.0
@@ -204,19 +204,20 @@ function checkKeywords() {
 function editNotify() {
     console.log('#### Code editNotify run ####');
     const orgNotifydict = {
-        'esf': 'Please escalated according to the Label tags and document.<br>\
-        https://172.18.2.13/books/customers/page/esf-cortex-endpoint-group-jira-organization-mapping',
-        'swireproperties':
-            'Please escalated according to the group, hostname value.<br>\
-        Check if additional Participants need to be added through HK_MSS_SOP.doc',
-        'lsh-hk':
-            'Please escalated according to the Label tags and document.<br>\
-        http://172.18.2.13/books/customers/page/lsh-hk-lei-shing-hong-hk',
         'Dev Team':
             'Please do NOT escalate to the customer<br>\
-        AND contact Dev Team via Teams Conversation first to confirm if it is due to their operatation',
+            AND contact Dev Team via Teams Conversation first to confirm if it is due to their operatation',
+        'esf': 'Please escalated according to the Label tags and document.<br>\
+            https://172.18.2.13/books/customers/page/esf-cortex-endpoint-group-jira-organization-mapping',
+        'swireproperties':
+            'Please escalated according to the group, hostname value.<br>\
+            Check if additional Participants need to be added through HK_MSS_SOP.doc',
+        'lsh-hk':
+            'Please escalated according to the Label tags and document.<br>\
+            http://172.18.2.13/books/customers/page/lsh-hk-lei-shing-hong-hk',
         'toysrus':
-            'If the alert is related to Malicious or Unwanted software, there is NO NEED to escalate.<br> Please help the customer run full scan on MDE and then close ticket. Finally, add full scan screenshots in internal comments'
+            'If the alert is related to Malicious or Unwanted software, there is NO NEED to escalate.<br>\
+            Please help the customer run full scan on MDE and then close ticket. Finally, add full scan screenshots in internal comments'
     };
     const LogSourceDomain = $('#customfield_10223-val').text().trim();
     const Labels = $('.labels-wrap .labels li a span').text();

--- a/BTAS.js
+++ b/BTAS.js
@@ -263,6 +263,7 @@ function editNotify() {
             });
         }
     }
+
     addEditonClick();
 
     function generateEditnotify() {
@@ -744,6 +745,68 @@ function CBAlertHandler() {
     addButton('openCB', 'CB', openCB);
 }
 
+function WineventAlertHandler() {
+    console.log('#### Code WineventAlertHandler run ####');
+    function extractLog() {
+        const LogSourceDomain = $('#customfield_10223-val').text().trim();
+        let rawLog = $('#field-customfield_10219 > div:first-child > div:nth-child(2)').text().trim().split('\n');
+        return { LogSourceDomain, rawLog };
+    }
+    const { LogSourceDomain, rawLog } = extractLog();
+
+    function parseLog(rawLog) {
+        const alertInfo = rawLog.reduce((acc, log) => {
+            try {
+                const { win } = JSON.parse(log);
+                const { eventdata, system } = win;
+                const alertTitle = $('#summary-val')
+                    .text()
+                    .trim()
+                    .replace(/[\[(].*?[\])]/g, '');
+                const alertHost = system.computer;
+                const alertExtraInfo = {
+                    UserName: eventdata.subjectUserName,
+                    TargetUserName: eventdata.targetUserName,
+                    Member: eventdata.memberName,
+                    Process: eventdata.newProcessName,
+                    Command: eventdata.commandLine,
+                    ParentProcess: eventdata.parentProcessName,
+                    IP: eventdata.ipAddress,
+                    ObjectDN: eventdata.objectDN,
+                    ObjectGUID: eventdata.objectGUID
+                };
+                acc.push({ alertTitle, alertHost, alertExtraInfo });
+            } catch (error) {
+                console.error(`Error: ${error.message}`);
+            }
+            return acc;
+        }, []);
+        return alertInfo;
+    }
+    const alertInfo = parseLog(rawLog);
+
+    function generateDescription() {
+        const alertDescriptions = [];
+        for (const info of alertInfo) {
+            let desc = `Observed${info.alertTitle}\nHost: ${info.alertHost}\n`;
+            for (const key in info.alertExtraInfo) {
+                if (Object.hasOwnProperty.call(info.alertExtraInfo, key)) {
+                    const value = info.alertExtraInfo[key];
+                    if (value !== undefined) {
+                        desc += `${key}: ${value}\n`;
+                    }
+                }
+            }
+            desc += '\n' + 'Please help to verify if this activity is legitimate.' + '\n';
+            alertDescriptions.push(desc);
+        }
+        const alertMsg = [...new Set(alertDescriptions)].join('\n');
+        alert(alertMsg);
+    }
+
+    addButton('generateDescription', 'Description', generateDescription);
+}
+
 (function () {
     'use strict';
 
@@ -776,7 +839,8 @@ function CBAlertHandler() {
                 'mde-api-json': MDEAlertHandler,
                 'sangfor-ccom-json': HTSCAlertHandler,
                 'CarbonBlack': CBAlertHandler,
-                'carbonblack_cef': CBAlertHandler
+                'carbonblack_cef': CBAlertHandler,
+                'windows_eventchannel': WineventAlertHandler
             };
             const DecoderName = $('#customfield_10807-val').text().trim();
             const handler = handlers[DecoderName];

--- a/BTAS.js
+++ b/BTAS.js
@@ -13,6 +13,8 @@
 // @require      https://code.jquery.com/jquery-3.6.4.min.js
 // @grant        GM_registerMenuCommand
 // @grant        GM_unregisterMenuCommand
+// @run-at       context-menu
+// @grant        GM_xmlhttpRequest
 // ==/UserScript==
 
 var $ = window.jQuery;
@@ -202,26 +204,32 @@ function checkKeywords() {
  */
 function editNotify(LogSourceDomain, LogSource, Labels, TicketAutoEscalate) {
     console.log('#### Code editNotify run ####');
-    const orgNotifydict = {
-        'Dev Team':
-            'Please do NOT escalate to the customer<br>\
-            AND contact Dev Team via Teams Conversation first to confirm if it is due to their operatation',
-        'esf': 'Please escalated according to the Label tags and document.<br>\
-            https://172.18.2.13/books/customers/page/esf-cortex-endpoint-group-jira-organization-mapping',
-        'swireproperties':
-            'Please escalated according to the group, hostname value.<br>\
-            Check if additional Participants need to be added through HK_MSS_SOP.doc',
-        'lsh-hk':
-            'Please escalated according to the Label tags and document.<br>\
-            http://172.18.2.13/books/customers/page/lsh-hk-lei-shing-hong-hk',
-        'toysrus':
-            'If the alert is related to Malicious or Unwanted software, there is NO NEED to escalate.<br>\
-            Please help the customer run full scan on MDE and then close ticket. Finally, add full scan screenshots in internal comments',
-        'Auto Escalate':
-            'All automatically upgraded tickets can NOT be closed directly, and need to be upgraded to the customer. Only need to add a description and ATT&CK, and wait for the customer to confirm before closing'
-    };
+    const orgNotifydict = {};
 
-    function addEditonClick() {
+    function fetchOrgNotifydict() {
+        GM_xmlhttpRequest({
+            method: 'GET',
+            url: 'https://example.com/path/to/orgNotifydict.json', // 将URL替换为JSON文件所在的服务器地址
+            onload: function (response) {
+                if (response.status === 200) {
+                    const data = JSON.parse(response.responseText);
+                    // 在这里处理获取到的data，例如将它存储到变量orgNotifydict中
+                    const orgNotifydict = data;
+                    // 然后调用处理函数
+                    addEditonClick(orgNotifydict);
+                } else {
+                    console.error('Error fetching orgNotifydict:', response.status);
+                }
+            },
+            onerror: function (error) {
+                console.error('Error fetching orgNotifydict:', error);
+            }
+        });
+    }
+
+    fetchOrgNotifydict();
+
+    function addEditonClick(orgNotifydict) {
         // # Add a click event listener to the "Edit" button related to the "LogSourceDomain" field
         if (
             LogSourceDomain.includes('esf') ||
@@ -277,7 +285,7 @@ function editNotify(LogSourceDomain, LogSource, Labels, TicketAutoEscalate) {
             });
         }
     }
-    addEditonClick();
+    //addEditonClick();
 
     function generateEditnotify() {
         const toolbar = $('.aui-toolbar2-primary');

--- a/BTAS.js
+++ b/BTAS.js
@@ -13,8 +13,9 @@
 // @require      https://code.jquery.com/jquery-3.6.4.min.js
 // @grant        GM_registerMenuCommand
 // @grant        GM_unregisterMenuCommand
-// @run-at       context-menu
 // @grant        GM_xmlhttpRequest
+// @connect      *
+// @run-at       start
 // ==/UserScript==
 
 var $ = window.jQuery;
@@ -202,21 +203,18 @@ function checkKeywords() {
  * It adds click event listeners to the "Edit" button based on certain conditions,
  * and generates a specific HTML element for the edit notification.
  */
-function editNotify(LogSourceDomain, LogSource, Labels, TicketAutoEscalate) {
+function editNotify(ValueFromPage) {
     console.log('#### Code editNotify run ####');
-    const orgNotifydict = {};
 
     function fetchOrgNotifydict() {
         GM_xmlhttpRequest({
             method: 'GET',
-            url: 'https://example.com/path/to/orgNotifydict.json', // 将URL替换为JSON文件所在的服务器地址
+            url: 'https://raw.githubusercontent.com/Dyebasedink/BTAS/Dev/notify.json',
             onload: function (response) {
                 if (response.status === 200) {
                     const data = JSON.parse(response.responseText);
-                    // 在这里处理获取到的data，例如将它存储到变量orgNotifydict中
-                    const orgNotifydict = data;
-                    // 然后调用处理函数
-                    addEditonClick(orgNotifydict);
+                    addClickListener(data);
+                    generateNotify();
                 } else {
                     console.error('Error fetching orgNotifydict:', response.status);
                 }
@@ -226,75 +224,57 @@ function editNotify(LogSourceDomain, LogSource, Labels, TicketAutoEscalate) {
             }
         });
     }
-
     fetchOrgNotifydict();
 
-    function addEditonClick(orgNotifydict) {
-        // # Add a click event listener to the "Edit" button related to the "LogSourceDomain" field
-        if (
-            LogSourceDomain.includes('esf') ||
-            LogSourceDomain.includes('swireproperties') ||
-            LogSourceDomain.includes('lsh-hk') ||
-            LogSourceDomain.includes('toysrus')
-        ) {
-            const orgNotify = orgNotifydict[LogSourceDomain];
-            $('#edit-issue').on('click', () => {
-                showFlag('warning', `${LogSourceDomain} ticket`, `${orgNotify}`, 'manual');
-            });
+    // Add a click event listener to button
+    function addClickListener(orgNotifydict) {
+        // get button path
+        function clickButton(click) {
+            const buttonMap = {
+                Edit: '#edit-issue',
+                Resolve: '#action_id_761'
+            };
+            return buttonMap[click] || '';
         }
-        if (LogSourceDomain.includes('kerrypropshk')) {
-            if (Labels === 'UnassignedGroup') {
-                $('#edit-issue').on('click', () => {
-                    showFlag(
-                        'warning',
-                        'kerrypropshk UnassignedGroup ticket',
-                        'Please note that if the host starts with cn/sz/bj/sh, Do NOT escalate it on Jira.<br>\
-                    Instead, share the issue key and MDE link with Desen and Barry.<br>\
-                    Then, choose "Won\'t Do" as the Resolution and Resolve this issue.<br>\
-                    In the Comments, mention that the host belongs to PRC and has been handed over to the SH team for handling.',
-                        'manual'
-                    );
-                });
-            } else {
-                $('#edit-issue').on('click', () => {
-                    showFlag(
-                        'warning',
-                        'kerrypropshk ticket',
-                        'Please copy the description to the comments for the customer',
-                        'manual'
-                    );
-                });
+
+        // check all the condition
+        function checkProperties(properties) {
+            return (
+                Object.keys(properties).length === 0 ||
+                Object.entries(properties).every(([property, value]) => {
+                    return Object.keys(ValueFromPage).includes(property) && value == ValueFromPage[property];
+                })
+            );
+        }
+
+        function processSection(sectionKey) {
+            const sectionData = orgNotifydict[sectionKey];
+            const valueFromPage = ValueFromPage[sectionKey];
+            for (const key in sectionData) {
+                if (valueFromPage.includes(key)) {
+                    const { ticketname, message, properties, click } = sectionData[key];
+                    const button = clickButton(click);
+                    if (checkProperties(properties)) {
+                        $(button).on('click', () => {
+                            showFlag('warning', `${ticketname} ticket`, `${message}`, 'manual');
+                        });
+                    }
+                }
             }
         }
-        // # Add a click event listener to the "Edit" button related to the "LogSource" field
-        if (
-            LogSource.includes('plwazag') ||
-            LogSource.includes('LogCollector') ||
-            LogSource.includes('.int.darklab.hk')
-        ) {
-            const orgNotify = orgNotifydict['Dev Team'];
-            $('#edit-issue').on('click', () => {
-                showFlag('warning', `${LogSource} ticket`, `${orgNotify}`, 'manual');
-            });
-        }
-        // # Add a click event listener to the "Resolve this issue" button related to the "Log Source Domain" field
-        if (TicketAutoEscalate == 'Yes') {
-            const orgNotify = orgNotifydict['Auto Escalate'];
-            $('#action_id_761').on('click', () => {
-                showFlag('warning', `Auto Escalate ticket`, `${orgNotify}`, 'manual');
-            });
-        }
-    }
-    //addEditonClick();
 
-    function generateEditnotify() {
+        processSection('LogSourceDomain');
+        processSection('LogSource');
+        processSection('TicketAutoEscalate');
+    }
+
+    // add a element into toolbar
+    function generateNotify() {
         const toolbar = $('.aui-toolbar2-primary');
         const element = $('<div id="generateEditnotify"></div>');
         toolbar.append(element);
     }
-    generateEditnotify();
 }
-
 /**
  * Creates a new button and adds it to the DOM.
  * @param {string} id - The ID attribute for the new button element.
@@ -317,7 +297,6 @@ function addButton(id, text, onClick) {
  * Creates three buttons on a JIRA issue page to handle Cortex XDR alerts
  * The buttons allow users to generate a description of the alerts, open the alert card page and timeline page
  */
-function cortexAlertHandler(rawLog, LogSourceDomain) {
 function cortexAlertHandler(rawLog, LogSourceDomain) {
     console.log('#### Code cortexAlertHandler run ####');
     /**
@@ -852,9 +831,11 @@ function WineventAlertHandler(rawLog) {
         const Labels = $('.labels-wrap .labels li a span').text();
         const LogSource = $('#customfield_10204-val').text().trim();
         const TicketAutoEscalate = $('#customfield_12202-val').text().trim();
+        const ValueFromPage = { LogSourceDomain, Labels, LogSource, TicketAutoEscalate };
+        // If it pops up once, it will not be reminded again
         if ($('#issue-content').length && !$('#generateEditnotify').length) {
             console.log('#### Code Issue page: Edit Notify ####');
-            editNotify(LogSourceDomain, LogSource, Labels, TicketAutoEscalate);
+            editNotify(ValueFromPage);
         }
     }, 3000);
 })();

--- a/BTAS.js
+++ b/BTAS.js
@@ -17,11 +17,6 @@
 
 var $ = window.jQuery;
 
-const LogSourceDomain = $('#customfield_10223-val').text().trim();
-const Labels = $('.labels-wrap .labels li a span').text();
-const LogSource = $('#customfield_10204-val').text().trim();
-const rawLog = $('#field-customfield_10219 > div:first-child > div:nth-child(2)').text().trim().split('\n');
-
 /**
  * This function creates and displays a flag using AJS.flag function
  * @param {string} type - The type of flag, can be one of the following: "success", "info", "warning", "error"
@@ -205,7 +200,7 @@ function checkKeywords() {
  * It adds click event listeners to the "Edit" button based on certain conditions,
  * and generates a specific HTML element for the edit notification.
  */
-function editNotify() {
+function editNotify(LogSourceDomain, LogSource, Labels) {
     console.log('#### Code editNotify run ####');
     const orgNotifydict = {
         'Dev Team':
@@ -314,7 +309,7 @@ function addButton(id, text, onClick) {
  * Creates three buttons on a JIRA issue page to handle Cortex XDR alerts
  * The buttons allow users to generate a description of the alerts, open the alert card page and timeline page
  */
-function cortexAlertHandler() {
+function cortexAlertHandler(rawLog, LogSourceDomain) {
     console.log('#### Code cortexAlertHandler run ####');
     /**
      * Extracts the log information and organization name from the current JIRA issue page
@@ -335,12 +330,10 @@ function cortexAlertHandler() {
         'welab': 'https://welabbank.xdr.sg.paloaltonetworks.com/'
     };
     function extractLog(orgDict) {
-        const LogSourceDomain = $('#customfield_10223-val').text().trim();
         const orgNavigator = orgDict[LogSourceDomain];
-        let rawLog = $('#field-customfield_10219 > div:first-child > div:nth-child(2)').text().trim().split('\n');
-        return { LogSourceDomain, orgNavigator, rawLog };
+        return orgNavigator;
     }
-    const { LogSourceDomain, orgNavigator, rawLog } = extractLog(orgDict);
+    const orgNavigator = extractLog(orgDict);
 
     /**
      * Parse the relevant information from the raw log data
@@ -497,7 +490,7 @@ function cortexAlertHandler() {
     addButton('openTimeline', 'Timeline', openTimeline);
 }
 
-function MDEAlertHandler() {
+function MDEAlertHandler(rawLog) {
     console.log('#### Code MDEAlertHandler run ####');
 
     function parseLog(rawLog) {
@@ -534,7 +527,6 @@ function MDEAlertHandler() {
         return alertInfo;
     }
     const alertInfo = parseLog(rawLog);
-    // console.info(`alertInfo: ${alertInfo}`);
 
     function generateDescription() {
         const alertDescriptions = [];
@@ -560,7 +552,7 @@ function MDEAlertHandler() {
     addButton('openMDE', 'MDE', openMDE);
 }
 
-function HTSCAlertHandler() {
+function HTSCAlertHandler(rawLog) {
     console.log('#### Code HTSCAlertHandler run ####');
 
     function decodeHtml(encodedString) {
@@ -608,7 +600,7 @@ function HTSCAlertHandler() {
     addButton('generateDescription', 'Description', generateDescription);
 }
 
-function CBAlertHandler() {
+function CBAlertHandler(rawLog, LogSourceDomain) {
     console.log('#### Code CBAlertHandler run ####');
 
     // For Swire
@@ -742,7 +734,7 @@ function CBAlertHandler() {
     addButton('openCB', 'CB', openCB);
 }
 
-function WineventAlertHandler() {
+function WineventAlertHandler(rawLog) {
     console.log('#### Code WineventAlertHandler run ####');
 
     function parseLog(rawLog) {
@@ -821,6 +813,8 @@ function WineventAlertHandler() {
 
     // Issue page: Alert Handler
     setInterval(() => {
+        const LogSourceDomain = $('#customfield_10223-val').text().trim();
+        const rawLog = $('#field-customfield_10219 > div:first-child > div:nth-child(2)').text().trim().split('\n');
         if ($('#issue-content').length && !$('#generateDescription').length) {
             console.log('#### Code Issue page: Alert Handler ####');
             const handlers = {
@@ -832,10 +826,9 @@ function WineventAlertHandler() {
                 'windows_eventchannel': WineventAlertHandler
             };
             const DecoderName = $('#customfield_10807-val').text().trim();
-
             const handler = handlers[DecoderName];
             if (handler) {
-                handler();
+                handler(rawLog, LogSourceDomain);
             }
         }
     }, 3000);
@@ -850,9 +843,12 @@ function WineventAlertHandler() {
 
     // Issue page: Edit Notify
     setInterval(() => {
+        const LogSourceDomain = $('#customfield_10223-val').text().trim();
+        const Labels = $('.labels-wrap .labels li a span').text();
+        const LogSource = $('#customfield_10204-val').text().trim();
         if ($('#issue-content').length && !$('#generateEditnotify').length) {
             console.log('#### Code Issue page: Edit Notify ####');
-            editNotify();
+            editNotify(LogSourceDomain, LogSource, Labels);
         }
     }, 3000);
 })();

--- a/BTAS.js
+++ b/BTAS.js
@@ -14,8 +14,8 @@
 // @grant        GM_registerMenuCommand
 // @grant        GM_unregisterMenuCommand
 // @grant        GM_xmlhttpRequest
-// @connect      *
-// @run-at       start
+// @connect      raw.githubusercontent.com
+// @run-at       document-idle
 // ==/UserScript==
 
 var $ = window.jQuery;

--- a/BTAS.js
+++ b/BTAS.js
@@ -17,12 +17,6 @@
 
 var $ = window.jQuery;
 
-const LogSourceDomain = $('#customfield_10223-val').text().trim();
-const Labels = $('.labels-wrap .labels li a span').text();
-const LogSource = $('#customfield_10204-val').text().trim();
-const rawLog = $('#field-customfield_10219 > div:first-child > div:nth-child(2)').text().trim().split('\n');
-const TicketAutoEscalate = $('#customfield_12202-val').text().trim();
-
 /**
  * This function creates and displays a flag using AJS.flag function
  * @param {string} type - The type of flag, can be one of the following: "success", "info", "warning", "error"
@@ -206,7 +200,7 @@ function checkKeywords() {
  * It adds click event listeners to the "Edit" button based on certain conditions,
  * and generates a specific HTML element for the edit notification.
  */
-function editNotify(LogSourceDomain, LogSource, Labels) {
+function editNotify(LogSourceDomain, LogSource, Labels, TicketAutoEscalate) {
     console.log('#### Code editNotify run ####');
     const orgNotifydict = {
         'Dev Team':
@@ -852,9 +846,10 @@ function WineventAlertHandler(rawLog) {
         const LogSourceDomain = $('#customfield_10223-val').text().trim();
         const Labels = $('.labels-wrap .labels li a span').text();
         const LogSource = $('#customfield_10204-val').text().trim();
+        const TicketAutoEscalate = $('#customfield_12202-val').text().trim();
         if ($('#issue-content').length && !$('#generateEditnotify').length) {
             console.log('#### Code Issue page: Edit Notify ####');
-            editNotify(LogSourceDomain, LogSource, Labels);
+            editNotify(LogSourceDomain, LogSource, Labels, TicketAutoEscalate);
         }
     }, 3000);
 })();

--- a/notify.json
+++ b/notify.json
@@ -1,0 +1,26 @@
+{
+    "LogSourceDomain": {
+        "esf": {
+            "message": "Please escalated according to the Label tags and document.<br>https://172.18.2.13/books/customers/page/esf-cortex-endpoint-group-jira-organization-mapping",
+            "properties": {},
+            "click": "Edit"
+        },
+        "kerrypropshk": {
+            "message": "Please note that if the host starts with cn/sz/bj/sh, Do NOT escalate it on Jira.<br>Instead, share the issue key and MDE link with Desen and Barry.<br>Then, choose 'Won't Do as the Resolution and Resolve this issue.<br>In the Comments, mention that the host belongs to PRC and has been handed over to the SH team for handling.",
+            "properties": { "Labels": ["UnassignedGroup"] },
+            "click": "Edit"
+        }
+    },
+    "LogSource": {
+        ".int.darklab.hk": {
+            "mseeage": "Please do NOT escalate to the customer<br>AND contact Dev Team via Teams Conversation first to confirm if it is due to their operatation",
+            "properties": {},
+            "click": "Edit"
+        }
+    },
+    "TicketAutoEscalate": {
+        "message": "All automatically upgraded tickets can NOT be closed directly, and need to be upgraded to the customer. Only need to add a description and ATT&CK, and wait for the customer to confirm before closing",
+        "properties": {},
+        "click": "Resolve"
+    }
+}

--- a/notify.json
+++ b/notify.json
@@ -1,26 +1,62 @@
 {
     "LogSourceDomain": {
+        "swireproperties": {
+            "ticketname": "swireproperties",
+            "message": "Please escalated according to the group, hostname value.<br>Check if additional Participants need to be added through HK_MSS_SOP.doc",
+            "properties": {},
+            "click": "Edit"
+        },
+        "lsh-hk": {
+            "ticketname": "lsh-hk",
+            "message": "Please escalated according to the Label tags and document.<br>http://172.18.2.13/books/customers/page/lsh-hk-lei-shing-hong-hk",
+            "properties": {},
+            "click": "Edit"
+        },
+        "toysrus": {
+            "ticketname": "toysrus",
+            "message": "If the alert is related to Malicious or Unwanted software, there is NO NEED to escalate.<br>Please help the customer run full scan on MDE and then close ticket. Finally, add full scan screenshots in internal comments",
+            "properties": {},
+            "click": "Edit"
+        },
         "esf": {
+            "ticketname": "esf",
             "message": "Please escalated according to the Label tags and document.<br>https://172.18.2.13/books/customers/page/esf-cortex-endpoint-group-jira-organization-mapping",
             "properties": {},
             "click": "Edit"
         },
         "kerrypropshk": {
+            "ticketname": "kerrypropshk",
             "message": "Please note that if the host starts with cn/sz/bj/sh, Do NOT escalate it on Jira.<br>Instead, share the issue key and MDE link with Desen and Barry.<br>Then, choose 'Won't Do as the Resolution and Resolve this issue.<br>In the Comments, mention that the host belongs to PRC and has been handed over to the SH team for handling.",
-            "properties": { "Labels": ["UnassignedGroup"] },
+            "properties": { "Labels": "UnassignedGroup" },
             "click": "Edit"
         }
     },
     "LogSource": {
         ".int.darklab.hk": {
-            "mseeage": "Please do NOT escalate to the customer<br>AND contact Dev Team via Teams Conversation first to confirm if it is due to their operatation",
+            "ticketname": "Dev Team",
+            "message": "Please do NOT escalate to the customer<br>AND contact Dev Team via Teams Conversation first to confirm if it is due to their operatation",
+            "properties": {},
+            "click": "Edit"
+        },
+        "LogCollector": {
+            "ticketname": "Dev Team",
+            "message": "Please do NOT escalate to the customer<br>AND contact Dev Team via Teams Conversation first to confirm if it is due to their operatation",
+            "properties": {},
+            "click": "Edit"
+        },
+        "plwazag": {
+            "ticketname": "Dev Team",
+            "message": "Please do NOT escalate to the customer<br>AND contact Dev Team via Teams Conversation first to confirm if it is due to their operatation",
             "properties": {},
             "click": "Edit"
         }
     },
     "TicketAutoEscalate": {
-        "message": "All automatically upgraded tickets can NOT be closed directly, and need to be upgraded to the customer. Only need to add a description and ATT&CK, and wait for the customer to confirm before closing",
-        "properties": {},
-        "click": "Resolve"
+        "Yes": {
+            "ticketname": "Auto Escalate",
+            "message": "All automatically upgraded tickets can NOT be closed directly, and need to be upgraded to the customer. Only need to add a description and ATT&CK, and wait for the customer to confirm before closing",
+            "properties": {},
+            "click": "Resolve"
+        }
     }
 }


### PR DESCRIPTION
1. 将提醒事项列表单独抽离出来，通过网络的方式获取提醒列表
2. 在元数据头中增加run-at document-idle 指示脚本在网页加载完成后执行
3. 赋予GM_xmlhttpRequest权限用来网络获取提醒列表，并使用@connect来限制请求的域
4. 新增notify.json文件，用来保存提示事项